### PR TITLE
Close() may be called on a nil connection.

### DIFF
--- a/node.go
+++ b/node.go
@@ -382,11 +382,11 @@ func (currNode *Node) Send(to erl.Pid, message erl.Term) {
 
 func epmdC(n *Node, resp chan uint16) {
 	conn, err := net.Dial("tcp", ":4369")
-	defer conn.Close()
 	if err != nil {
 		resp <- 100
 		return
 	}
+	defer conn.Close()
 
 	epmdFROM := make(chan []byte)
 	go epmdREADER(conn, epmdFROM)


### PR DESCRIPTION
Function 'epmdC' was calling (a defered) Close() on a connection that will be nil if if EPMD is not running, resulting in a nil pointer dereference.
