### PR TITLE
Fix for ConnectEx tcp Exception

### DIFF
--- a/node.go
+++ b/node.go
@@ -392,8 +392,9 @@ func (currNode *Node) Send(to etf.Pid, message etf.Term) {
 }
 
 func epmdC(n *Node, resp chan uint16) {
-	conn, err := net.Dial("tcp", ":4369")
+	conn, err := net.Dial("tcp", "127.0.0.1:4369")
 	if err != nil {
+		nLog("Error calling net.Dial : %s", err.Error())
 		resp <- 100
 		return
 	}


### PR DESCRIPTION
Hey,

Running the example on windows with golang 1.4 I get the following error - 

```
Error Dial: dial tcp :4369: ConnectEx tcp: The requested address is not valid in its context.
```

The root cause appears to be the call

```
conn, err := net.Dial("tcp", ":4369")
```

This [link](http://golang.org/pkg/net/#ResolveTCPAddr) seems to say that a valid address is of the form "host:port"

I've added a fix plus an extra line of debugging.

Thanks,

Mark
